### PR TITLE
add Vivado support

### DIFF
--- a/bin/goa
+++ b/bin/goa
@@ -483,6 +483,9 @@ proc detect_build_system { } {
 	if {[file exists [file join src makefile]]} {
 		return make }
 
+	if {[file exists [file join src vivado.tcl]]} {
+		return vivado }
+
 	exit_with_error "unable to determine build system for [pwd]"
 }
 

--- a/share/goa/lib/build/vivado.tcl
+++ b/share/goa/lib/build/vivado.tcl
@@ -1,0 +1,78 @@
+
+proc create_or_update_build_dir { } {
+
+	global build_dir project_dir verbose
+	global project_name
+
+	# skip if project file already exists
+	if {[file exists [glob -nocomplain [file join $build_dir * *.xpr]]]} {
+		return
+	}
+
+	if {![file exists $build_dir]} {
+		file mkdir $build_dir }
+
+	set orig_pwd [pwd]
+	cd $build_dir
+
+	set cmd { }
+	lappend cmd vivado
+	lappend cmd "-nolog"
+	lappend cmd "-nojournal"
+	lappend cmd "-mode"
+	lappend cmd "batch"
+	lappend cmd "-source"
+	lappend cmd "[file join $project_dir src vivado.tcl]"
+	if {$verbose != 0} {
+		lappend cmd "-verbose"
+	}
+	lappend cmd "-tclargs"
+	lappend cmd "--origin_dir"
+	lappend cmd "[file join $orig_pwd src]"
+	lappend cmd "--project_name"
+	lappend cmd "vivado"
+
+	diag "create build directory via command:" {*}$cmd
+
+	if {[catch {exec -ignorestderr {*}$cmd | sed "/^#.*/d" | sed "s/^/\[$project_name:vivado\] /" >@ stdout} msg]} {
+		exit_with_error "build-directory creation via vivado failed:\n" $msg }
+
+	cd $orig_pwd
+}
+
+
+proc build { } {
+	global build_dir jobs project_name verbose tool_dir
+
+	set target "$project_name.bit"
+	if {[file exists [file join $build_dir $target]]} {
+		return
+	}
+
+	set orig_pwd [pwd]
+	cd $build_dir
+
+	set cmd { }
+	lappend cmd vivado
+	lappend cmd "-nolog"
+	lappend cmd "-nojournal"
+	lappend cmd "-mode"
+	lappend cmd "batch"
+	lappend cmd "-source"
+	lappend cmd "[file join $tool_dir vivado generate_bitstream.tcl]"
+	if {$verbose != 0} {
+		lappend cmd "-verbose"
+	}
+	lappend cmd "-tclargs"
+	lappend cmd "--jobs"
+	lappend cmd $jobs"
+	lappend cmd "--target"
+	lappend cmd $target"
+
+	diag "generating bitstream via command:" {*}$cmd
+
+	if {[catch {exec {*}$cmd | sed "/^#.*/d" | sed "s/^/\[$project_name:vivado\] /" >@ stdout} msg]} {
+		exit_with_error "build via vivado failed:\n" $msg }
+
+	cd $orig_pwd
+}

--- a/share/goa/vivado/generate_bitstream.tcl
+++ b/share/goa/vivado/generate_bitstream.tcl
@@ -1,0 +1,63 @@
+proc findProject { } {
+	set files [glob -nocomplain [file join * *.xpr]]
+	foreach file $files { return $file }
+
+	puts "ERROR: Could not find project file (.xpr) in build directory '[pwd]'\n"
+	return ""
+}
+
+set target "fpga.bit"
+
+set jobs "1"
+if { $::argc > 0 } {
+	for {set i 0} {$i < $::argc} {incr i} {
+		set option [string trim [lindex $::argv $i]]
+		switch -regexp -- $option {
+			"--jobs"         { incr i; set jobs   [lindex $::argv $i] }
+			"--target"       { incr i; set target [lindex $::argv $i] }
+		default {
+			if { [regexp {^-} $option] } {
+				puts "ERROR: Unknown option '$option' specified.\n"
+				return 1
+			}
+		}}
+	}
+}
+
+# find project file
+set project_file [findProject]
+if {![file exists $project_file]} { return 1 }
+
+open_project $project_file
+
+set runs [list "synth_1" "impl_1"]
+# find runs
+if {[string equal [get_runs -quiet $runs] ""]} {
+	puts "ERROR: Runs '$runs' not found.\n"
+	return 1
+}
+
+foreach run $runs { reset_run $run }
+
+puts "Generating bitstream"
+launch_runs $runs -jobs $jobs -quiet
+
+set last_run [lindex $runs [llength $runs]-1]
+while { [get_property PROGRESS [get_runs $last_run]] != "100%" } {
+	set error 0
+
+	# print status
+	foreach run [get_runs] status [get_property STATUS [get_runs]] progress [get_property PROGRESS [get_runs]] {
+		puts "$progress\t - $run\t - $status"
+		if {[regexp "ERROR" $status]} { set error 1 }
+	}
+
+	if { $error } { return 1}
+	wait_on_run $last_run -timeout 1
+}
+
+# export bitstream
+open_impl_design $last_run
+write_bitstream -force $target
+close_project
+exit 0


### PR DESCRIPTION
This commit adds support for recreating Xilinx Vivado projects and generating bitstreams. For this purpose, Goa detects the presence of a vivado.tcl file in the src/ directory. This file must be created in Vivado with the following command:

write_project_tcl -paths_relative_to /path/to/workspace/dir vivado.tcl

Furthermore, the required source files (as referenced in the checkRequiredFiles procedure in the tcl file) must be manually copied into the src/ directory.

Note that the Vivado tools must have been installed and sourced.