### PR TITLE
Vivado: also generate device_manager.config

### DIFF
--- a/share/goa/doc/build-systems.txt
+++ b/share/goa/doc/build-systems.txt
@@ -60,6 +60,20 @@ the source files into relative paths. Furthermore, the required source files
 (as referenced in the checkRequiredFiles procedure in the tcl file) must be
 manually copied into the src/ directory with their unmodified relative paths.
 
+Furthermore, if Goa finds a devices file in the src/ directory, it generates a
+devices_manager.config. The devices file is an XML file that has the following
+structure:
+
+*<devices> <device name="axi_dma_0" type="axi_dma"/> </devices>*
+
+Each device node must at least contain a name or a type attribute. These
+attributes are used for module lookup in the hardware design. Goa automatically
+adds io_mem nodes if the corresponding module has a memory-mapped register
+interface. Contained irq nodes are copies whereas property nodes may be used
+for specifying XPAR_ parameter definitions for Xilinx standalone drivers.
+Missing property values are supplemented by definitions found in the hardware
+design.
+
 Note that Goa writes the bistream to a <project_name>.bit file.
 
 

--- a/share/goa/vivado/generate_devices_config.tcl
+++ b/share/goa/vivado/generate_devices_config.tcl
@@ -1,0 +1,101 @@
+#!/usr/bin/tclsh
+
+package require tdom
+
+set output "devices_manager.config"
+if { $::argc > 0 } {
+	for {set i 0} {$i < $::argc} {incr i} {
+		set option [string trim [lindex $::argv $i]]
+		switch -regexp -- $option {
+			"--output"     { incr i; set output   [lindex $::argv $i] }
+			"--template"   { incr i; set template [lindex $::argv $i] }
+			"--xsa"        { incr i; set xsa      [lindex $::argv $i] }
+		default {
+			if { [regexp {^-} $option] } {
+				puts "ERROR: Unknown option '$option' specified.\n"
+				return 1
+			}
+		}}
+	}
+}
+
+
+set bit_name     [file tail [file rootname $xsa].bit]
+set xsa_doc      [dom parse [exec unzip -p $xsa *.hwh]]
+set template_doc [dom parse [exec cat $template]]
+
+set out_xml "
+<config>
+	<bitstream name=\"$bit_name\">
+		<devices/>
+	</bitstream>
+</config>
+"
+
+set out_doc [dom parse $out_xml]
+set out_node [$out_doc selectNodes /config/bitstream/devices]
+
+foreach device [$template_doc selectNodes //device] {
+	# find module by type/name in xsa
+	foreach module [$xsa_doc selectNodes //MODULE] {
+		set modtype  [$module @MODTYPE]
+		set instance [$module @INSTANCE]
+		if {[$device hasAttribute type] && $modtype  != [$device @type]} { continue }
+		if {[$device hasAttribute name] && $instance != [$device @name]} { continue }
+
+		set node [$out_doc createElement device]
+		$node setAttribute type $modtype
+		$node setAttribute name $instance
+
+		# add <io_mem> for each corresponding memrange
+		set memranges [$xsa_doc selectNodes //MEMRANGE\[@MEMTYPE="REGISTER"\]\[@INSTANCE="$instance"\]]
+		foreach memrange $memranges {
+			set io_mem_base [$memrange @BASEVALUE]
+			set io_mem_high [$memrange @HIGHVALUE]
+			$node appendXML "<io_mem address=\"$io_mem_base\" size=\"[format 0x%x [expr $io_mem_high - $io_mem_base + 1]]\"/>"
+		}
+
+		# copy irq nodes
+		foreach irq [$device selectNodes .//irq] {
+			$node appendXML [$irq asXML]
+		}
+
+		# find clocks
+		set clocklist [list]
+		foreach clk [$module selectNodes .//PORT\[@CLKFREQUENCY\]] {
+			set connection [$clk selectNodes .//CONNECTION\[@PORT\]]
+			if {[regexp "FCLK_CLK(\[0-9\])" [$connection @PORT] clkname clknum]} {
+				if {$clkname in $clocklist} { continue }
+				$node appendXML "<clock name=\"fpga$clknum\" driver_name=\"fpga$clknum\" rate=\"[$clk @CLKFREQUENCY]\"/>"
+				lappend clocklist $clkname
+			}
+		}
+
+		# find parameters and fill in missing values
+		foreach prop [$device selectNodes .//property] {
+			set name [$prop @name]
+			set propnode [$out_doc createElement property]
+			$propnode setAttribute name $name
+
+			if {![$prop hasAttribute "value"]} {
+				set modtype_pattern "XPAR_(.+)__(.+)"
+				regexp $modtype_pattern $name dummy1 dummy2 param
+				set param_node [$module selectNodes .//PARAMETER\[@NAME="C_$param"\]]
+				$propnode setAttribute value [$param_node @VALUE]
+			} else {
+				$propnode setAttribute value [$prop @value]
+			}
+
+			$node appendChild $propnode
+		}
+
+		$out_node appendChild $node
+	}
+}
+
+
+set output_fd [open $output w+]
+puts $output_fd [$out_doc asXML]
+close $output_fd
+
+exit 0


### PR DESCRIPTION
@nfeske I extended the vivado support to include a devices_manager.config in the bitstream archives. This config is intended to be used by the drivers_fpga-zynq package.