### PR TITLE
improve Vivado support

### DIFF
--- a/share/goa/vivado/generate_devices_config.tcl
+++ b/share/goa/vivado/generate_devices_config.tcl
@@ -21,7 +21,9 @@ if { $::argc > 0 } {
 
 
 set bit_name     [file tail [file rootname $xsa].bit]
-set xsa_doc      [dom parse [exec unzip -p $xsa *.hwh]]
+set sysdef_doc   [dom parse [exec unzip -p $xsa sysdef.xml]]
+set default_bd   [[$sysdef_doc selectNodes //File\[@BD_TYPE="DEFAULT_BD"\]] @Name]
+set xsa_doc      [dom parse [exec unzip -p $xsa $default_bd]]
 set template_doc [dom parse [exec cat $template]]
 
 set out_xml "

--- a/share/goa/vivado/generate_devices_config.tcl
+++ b/share/goa/vivado/generate_devices_config.tcl
@@ -62,6 +62,21 @@ foreach device [$template_doc selectNodes //device] {
 			$node appendXML [$irq asXML]
 		}
 
+		# copy reserved_memory nodes
+		foreach reserved_mem [$device selectNodes .//reserved_memory] {
+			$node appendXML [$reserved_mem asXML]
+		}
+
+		# copy reset-domain nodes
+		foreach reset [$device selectNodes .//reset-domain] {
+			$node appendXML [$reset asXML]
+		}
+
+		# copy power-domain nodes
+		foreach power [$device selectNodes .//power-domain] {
+			$node appendXML [$power asXML]
+		}
+
 		# find clocks
 		set clocklist [list]
 		foreach clk [$module selectNodes .//PORT\[@CLKFREQUENCY\]] {


### PR DESCRIPTION
@nfeske Please consider these two commits for merging. Commit 080c204 fixes an issue that popped up when a hardware design contains multiple block diagrams. Commit 6f08b6b completes the support for specifying devices ROM templates.